### PR TITLE
Support RDF files and serializing to request formats

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,1 +1,6 @@
 sourceDirectory: /usr/local/var/temp_files
+validRdfFormats:
+  - { format: "turtle", mimeType: "text/turtle", extension : "ttl" }
+  - { format: "jsonld", mimeType: "application/ld+json", extension: "jsonld" }
+  - { format: "ntriples", mimeType: "application/n-triples", extension: "n3" }
+defaultRdfFormat: turtle

--- a/src/Controller/ResourceController.php
+++ b/src/Controller/ResourceController.php
@@ -53,16 +53,8 @@ class ResourceController implements ControllerProviderInterface
   public function getOrHead(Application $app, Request $request, $path)
   {
 
-    $valid_types = [
-      "text/turtle" => "turtle",
-      "application/ld+json" => "jsonld",
-      "application/n-triples" => "ntriples"];
-
-    $format = "text/turtle";
-
-    if ($request->headers->has('accept') && array_key_exists($request->headers->get('accept'), $valid_types)) {
-      $format = $request->headers->get('accept');
-    }
+    // Get default responseFormat.
+    $responseFormat = $app['config']['defaultRdfFormat'];
 
     $docroot = $app['config']['sourceDirectory'];
     if (!empty($path)) {
@@ -74,48 +66,33 @@ class ResourceController implements ControllerProviderInterface
       return new Response("Not Found", 404);
     }
 
+    if ($request->headers->has('accept')) {
+      $format = $this->getResponseFormat($app['config']['validRdfFormats'], $request);
+      if (!is_null($format)) {
+        $responseFormat = $format;
+      }
+    }
+
+
     // It is a file.
     if (is_file($requested_path)) {
-      $mimeType = mime_content_type($requested_path);
-      $headers = [
-        "Link" => "<http://www.w3.org/ns/ldp#NonRDFSource>; rel=\"type\"",
-        "Content-Type" => $mimeType,
-        "Content-Length" => filesize($requested_path),
-      ];
-      // Only read if we are going to use it.
-      if ($request->getMethod() == 'GET') {
-        // Probably best to stream the data out.
-        // http://silex.sensiolabs.org/doc/2.0/usage.html#streaming
-        $content = file_get_contents($requested_path);
-      }
+      $response = $this->getFile(
+        $requested_path,
+        $responseFormat,
+        $app['config']['validRdfFormats'],
+        ($request->getMethod() == 'GET')
+      );
+
     } else {
-      // Else we assume it is a directory.
-      $namespaces = new \EasyRdf_Namespace();
-      $namespaces->set("ldp", "http://www.w3.org/ns/ldp#");
-
-      $graph = new \EasyRdf_Graph();
-
-      $subject = $_SERVER['REQUEST_SCHEME'] . "://" . $_SERVER['SERVER_NAME'] . $_SERVER['REQUEST_URI'];
-      $predicate = "http://www.w3.org/ns/ldp#contains";
-
-      $headers = [
-        "Link" => "<http://www.w3.org/ns/ldp#BasicContainer>; rel=\"type\"",
-        "Content-Type" => $format,
-      ];
-
-      foreach (scandir($requested_path) as $filename) {
-        if (substr($filename, 0, 1) !== ".") {
-          $graph->addResource($subject, $predicate, $subject . (substr($subject, -1) != '/' ? '/' : '') . $filename);
-        }
-      }
-      $content = $graph->serialise($valid_types[$format]);
-      $headers["Content-Length"] = strlen($content);
+      // We assume it's a directory.
+      $response = $this->getDirectory(
+        $requested_path,
+        $responseFormat,
+        $app['config']['validRdfFormats'],
+        ($request->getMethod() == 'GET')
+      );
     }
-
-    if ($request->getMethod() == "HEAD") {
-      $content = "";
-    }
-    return new Response($content, 200, $headers);
+    return $response;
   }
 
   /**
@@ -129,5 +106,130 @@ class ResourceController implements ControllerProviderInterface
       "Allow" => "OPTIONS, GET, HEAD",
     ];
     return new Response('', 200, $headers);
+  }
+
+  /**
+   * Find the valid mimeType and
+   *
+   * @param array $validRdfFormats
+   *   Supported formats from the config.
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   The current request.
+   *
+   * @return string
+   *   EasyRdf "format" or null if not supported.
+   */
+  private function getResponseFormat(array $validRdfFormats, Request $request)
+  {
+    if ($request->headers->has('accept')) {
+      $accept = $request->getAcceptableContentTypes();
+      foreach ($accept as $item) {
+        $index = array_search($item, array_column($validRdfFormats, 'mimeType'));
+        if ($index !== FALSE) {
+          return $validRdfFormats[$index]['format'];
+        }
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Serve a file from the filesystem.
+   *
+   * @param $path
+   *   Path to file we are serving.
+   * @param $responseFormat
+   *   The format to respond in, if it is a RDFSource.
+   * @param array $validRdfFormats
+   *   The configured validRdfFormats.
+   * @param bool $doGet
+   *   Whether we are doing a GET or HEAD request.
+   * @return \Symfony\Component\HttpFoundation\Response
+   */
+  private function getFile($path, $responseFormat, array $validRdfFormats, bool $doGet = false) {
+    $headers = [];
+    // Plain might be RDF, check the file extension.
+    $dirChunks = explode(DIRECTORY_SEPARATOR, $path);
+    $filename = array_pop($dirChunks);
+    $filenameChunks = explode('.', $filename);
+    $extension = array_pop($filenameChunks);
+    $index = array_search($extension, array_column($validRdfFormats, 'extension'));
+    if ($index !== FALSE) {
+      // This is a RDF file.
+      $inputFormat = $validRdfFormats[$index]['format'];
+      $headers["Link"] = "<http://www.w3.org/ns/ldp#RDFSource>; rel=\"type\"";
+      $subject = $_SERVER['REQUEST_SCHEME'] . "://" . $_SERVER['SERVER_NAME'] . $_SERVER['REQUEST_URI'];
+
+      // Converting RDF from something to something else.
+      $graph = new \EasyRdf_Graph();
+      $graph->parseFile($path, $inputFormat, $subject);
+      $content = $graph->serialise($responseFormat);
+      $headers["Content-Length"] = strlen($content);
+
+      $index = array_search($responseFormat, array_column($validRdfFormats, 'format'));
+      if ($index !== false) {
+        $headers['Content-Type'] = $validRdfFormats[$index]['mimeType'];
+      }
+    } else {
+      // This is not a RDF file.
+      $contentLength = filesize($path);
+      $responseMimeType = mime_content_type($path);
+      $headers = [
+        "Content-Type" => $responseMimeType,
+        "Link" => "<http://www.w3.org/ns/ldp#NonRDFSource>; rel=\"type\"",
+        "Content-Length" => $contentLength,
+      ];
+
+      if ($doGet) {
+        // Probably best to stream the data out.
+        // http://silex.sensiolabs.org/doc/2.0/usage.html#streaming
+        $content = file_get_contents($path);
+      }
+    }
+    if (!$doGet) {
+      $content = '';
+    }
+    return new Response($content, 200, $headers);
+  }
+
+  /**
+   * @param $path
+   *   Path to file we are serving.
+   * @param $responseFormat
+   *   The format to respond in, if it is a RDFSource.
+   * @param array $validRdfFormats
+   *   The configured validRdfFormats.
+   * @param bool $doGet
+   *   Whether we are doing a GET or HEAD request.
+   * @return \Symfony\Component\HttpFoundation\Response
+   */
+  private function getDirectory($path, $responseFormat, array $validRdfFormats, bool $doGet) {
+
+    $subject = $_SERVER['REQUEST_SCHEME'] . "://" . $_SERVER['SERVER_NAME'] . $_SERVER['REQUEST_URI'];
+    $predicate = "http://www.w3.org/ns/ldp#contains";
+
+    $index = array_search($responseFormat, array_column($validRdfFormats, 'format'));
+    if ($index !== false) {
+      $responseMimeType = $validRdfFormats[$index]['mimeType'];
+    }
+    $headers = [
+      "Link" => "<http://www.w3.org/ns/ldp#BasicContainer>; rel=\"type\"",
+      "Content-Type" => $responseMimeType,
+    ];
+    $graph = new \EasyRdf_Graph();
+
+    foreach (new \DirectoryIterator($path) as $fileInfo) {
+      if ($fileInfo->isDot()) {
+        continue;
+      }
+      $graph->addResource($subject, $predicate, rtrim($subject, '/') . '/' . ltrim($fileInfo->getFilename(), '/'));
+    }
+
+    $content = $graph->serialise($responseFormat);
+    $headers["Content-Length"] = strlen($content);
+    if (!$doGet) {
+      $content = '';
+    }
+    return new Response($content, 200, $headers);
   }
 }


### PR DESCRIPTION
Support multiple Accept headers order by preference

Move valid RDF formats into configuration.

Still no Twig, but that can come next.

Mostly this moved the formats into the configuration file and added an extension parameter so I can tell if a file is a RDFSource document and then allow it to be serialized to the requested format.

This might be a bad idea, as it relies on file extensions. But (at least in my test server) they all returned a mime-type of text/plain.

Also allows for serialized directory listings. 

Tell me if this is getting too crazy for a simple static LDP server.

cheers 👍 