### PR TITLE
Issue 12

### DIFF
--- a/src/Controller/ResourceController.php
+++ b/src/Controller/ResourceController.php
@@ -108,17 +108,16 @@ class ResourceController implements ControllerProviderInterface
             $response = $this->getDirectoryHTML(
                 $app,
                 $request,
-                $requested_path,
-                $request->getMethod() == 'GET'
+                $requested_path
             );
         } else {
             // We assume it's a directory.
             $response = $this->getDirectory(
                 $request,
+                $response,
                 $requested_path,
                 $responseFormat,
-                $app['config']['validRdfFormats'],
-                $request->getMethod() == 'GET'
+                $app['config']['validRdfFormats']
             );
         }
         // We are trusting we have response here
@@ -318,6 +317,8 @@ class ResourceController implements ControllerProviderInterface
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
      *   The incoming request.
+     * @param \Symfony\Component\HttpFoundation\Response $response
+     *   The outgoing response.
      * @param $requested_path
      *   Path to file we are serving.
      * @param $responseFormat
@@ -326,8 +327,14 @@ class ResourceController implements ControllerProviderInterface
      *   The configured validRdfFormats.
     * @return \Symfony\Component\HttpFoundation\Response
      */
-    private function getDirectory(Request $request, $requested_path, $responseFormat, array $validRdfFormats)
-    {
+    private function getDirectory(
+        Request $request,
+        Response $response,
+        $requested_path,
+        $responseFormat,
+        array $validRdfFormats
+    ) {
+    
 
         $index = array_search($responseFormat, array_column($validRdfFormats, 'format'));
         if ($index !== false) {

--- a/src/Controller/ResourceController.php
+++ b/src/Controller/ResourceController.php
@@ -237,7 +237,7 @@ class ResourceController implements ControllerProviderInterface
                     readfile($requested_path);
                 };
 
-                return $app->stream($stream, 200, $response->headers);
+                return $app->stream($stream, 200, $response->headers->all());
             }
         }
 


### PR DESCRIPTION
Humble attempt to refactor around a new Etag/Last-Modified implementation some of the existing route controller methods and reuse of a single `Response` object by manipulating headers via native methods.

- PSR-2 checked on the file changed.
- Basic containers need a Etag strategy. 
- RDF files served via files get Etags from the source file, not the serialization, so that needs a rethinking (lets talk about that)

Side note: Testing files with extensions is complex in a test environment because routes don't resolve to PHP but try to resolve agains static files, so we need probably a better approach there.

Feel free to test, comment or even (how crazy) merge.